### PR TITLE
Timer plugin

### DIFF
--- a/plugins/Timer.py
+++ b/plugins/Timer.py
@@ -7,6 +7,7 @@ class Plugin(object):
     def __init__(self, pm):
         self.pm = pm
         self.db = defaultdict(arrow.utcnow)
+        self.name = "Timer"
 
     @staticmethod
     def register_events():
@@ -21,10 +22,10 @@ class Plugin(object):
     async def reset(self, message_object):
         delta = self.db[message_object.channel].humanize(only_distance = True)
         self.db[message_object.channel] = arrow.utcnow()
-        await self.pm.client.send_message(message_object.channel, f"Timer reset after {delta}.")
+        await self.pm.clientWrap.send_message(self.name, message_object.channel, f"Timer reset after {delta}.")
         await self.pm.client.delete_message(message_object)
 
     async def timer(self, message_object):
         delta = self.db[message_object.channel].humanize(only_distance = True)
-        await self.pm.client.send_message(message_object.channel, f"Timer has been running for {delta}.")
+        await self.pm.clientWrap.send_message(name, message_object.channel, f"Timer has been running for {delta}.")
         await self.pm.client.delete_message(message_object)

--- a/plugins/Timer.py
+++ b/plugins/Timer.py
@@ -1,0 +1,30 @@
+from util import Events
+from collections import defaultdict
+import arrow
+
+
+class Plugin(object):
+    def __init__(self, pm):
+        self.pm = pm
+        self.db = defaultdict(arrow.utcnow)
+
+    @staticmethod
+    def register_events():
+        return [Events.Command("timer"),Events.Command("reset")]
+
+    async def handle_command(self, message_object, command, args):
+        if command == "timer":
+            await self.timer(message_object)
+        if command == "reset":
+            await self.reset(message_object)
+
+    async def reset(self, message_object):
+        delta = self.db[message_object.channel].humanize(only_distance = True)
+        self.db[message_object.channel] = arrow.utcnow()
+        await self.pm.client.send_message(message_object.channel, f"Timer reset after {delta}.")
+        await self.pm.client.delete_message(message_object)
+
+    async def timer(self, message_object):
+        delta = self.db[message_object.channel].humanize(only_distance = True)
+        await self.pm.client.send_message(message_object.channel, f"Timer has been running for {delta}.")
+        await self.pm.client.delete_message(message_object)

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ urllib3==1.22
 websockets==5.0.1
 yarl==1.2.0
 youtube-dl==2017.3.20
+arrow=0.12.1


### PR DESCRIPTION
I've created the timer plugin as discussed. Plugin allows for the creation of running timers for each channel on a server. Note that timers are saved in RAM, and so are not preserved between restarts of the bot. Also timers are not destroyed when a channel is deleted (there appears to be no method in the bot to respond to channel deletion events), so in theory this could constitute a memory leak over a very long period of operation. However, considering the relative rarity of channel deletions and the fact that they are only done by moderators, I do not think it would ever pose a problem unless subjected to deliberately pathological input.