### PR TITLE
Split messages sent by ClientWrapper if they exceed max length of embed

### DIFF
--- a/ClientWrapper.py
+++ b/ClientWrapper.py
@@ -1,6 +1,10 @@
 import random
+from typing import List
 
 import discord
+
+
+EMBED_DESCRIPTION_MAX_LENGTH = 2048
 
 
 class ClientWrapper(object):
@@ -8,10 +12,39 @@ class ClientWrapper(object):
         self.pluginManager = pm
         self.client = pm.client
 
-    async def send_message(self, name, channel, message):
+    async def send_message_raw(self, name: str, channel: discord.TextChannel, message: str):
         em = discord.Embed(description=message, colour=self.get_color(name))
         msg = await channel.send(embed=em)
         return msg
+
+    async def send_message(self, name: str, channel: discord.TextChannel, message: str) -> List[discord.Message]:
+        if len(message) <= EMBED_DESCRIPTION_MAX_LENGTH:
+            return [await self.send_message_raw(name, channel, message)]
+        remaining_string: str = message
+        sent_messages = []
+        # TODO the splitting here doesn't care about text markup, so it might happen that e.g. code blocks get broken
+        # It is also pretty naive in terms of balancing the length of resulting messages, there are
+        # probably better algorithms if we want more balanced output
+        while len(remaining_string) > EMBED_DESCRIPTION_MAX_LENGTH:
+            truncated_string = remaining_string[:EMBED_DESCRIPTION_MAX_LENGTH]
+            last_newline_index = truncated_string.rfind('\n')
+            last_space_index = truncated_string.rfind(' ')
+            if last_newline_index >= EMBED_DESCRIPTION_MAX_LENGTH / 3:
+                remaining_string = remaining_string[last_newline_index + 1:]
+                to_send = truncated_string[:last_newline_index].strip()
+            elif last_space_index > 0:
+                remaining_string = remaining_string[last_space_index + 1:]
+                to_send = truncated_string[:last_space_index].strip()
+            else:
+                remaining_string = remaining_string[EMBED_DESCRIPTION_MAX_LENGTH:]
+                to_send = truncated_string.strip()
+            msg = await self.send_message_raw(name, channel, to_send)
+            sent_messages.append(msg)
+        remaining_string = remaining_string.strip()
+        if len(remaining_string) > 0:
+            msg = await self.send_message_raw(name, channel, remaining_string)
+            sent_messages.append(msg)
+        return sent_messages
 
     async def edit_message(self, name, old_message, new_message):
         em = discord.Embed(description=new_message, colour=self.get_color(name))

--- a/plugins/Poll.py
+++ b/plugins/Poll.py
@@ -16,8 +16,10 @@ class Plugin(AbstractPlugin):
             await self.poll(message_object, args[1].strip())
 
     async def poll(self, message_object, prompt):
-        if prompt.strip() is "":
+        if prompt.strip() == "":
             prompt = "Yay or Nay?"
-        poll_msg = await self.pm.clientWrap.send_message(self.name, message_object.channel, "**Poll:**\n" + prompt)
+        # current message character limit is 2000, so we should never get a split embed, but in case it changes
+        # in the future, attach reactions only to the last message
+        poll_msg = (await self.pm.clientWrap.send_message(self.name, message_object.channel, "**Poll:**\n" + prompt))[-1]
         await poll_msg.add_reaction('\U00002714')
         await poll_msg.add_reaction('\U00002716')

--- a/plugins/Race.py
+++ b/plugins/Race.py
@@ -56,12 +56,13 @@ class Plugin(AbstractPlugin):
         self.race = self.Race()
         self.race.participants = list()
         self.race.finish_pos = 1
-        race_start = await self.pm.clientWrap.send_message(self.name, message_object.channel,
-                                                           message_object.author.display_name +
-                                                           " has started a race! \n"
-                                                           "Type " + self.pm.botPreferences.commandPrefix +
-                                                           "joinrace [emoji] to "
-                                                           "join the race (30s)")
+        # this will always be a single message
+        race_start = (await self.pm.clientWrap.send_message(self.name, message_object.channel,
+                                                            message_object.author.display_name +
+                                                            " has started a race! \n"
+                                                            "Type " + self.pm.botPreferences.commandPrefix +
+                                                            "joinrace [emoji] to "
+                                                            "join the race (30s)"))[0]
         # Give users time to join
         self.race.open = True
         await asyncio.sleep(30)
@@ -134,9 +135,10 @@ class Plugin(AbstractPlugin):
                           ":snail:", ":bee:", ":elephant:", ":gorilla:", ":squid:"]
                 await self.user_join_as_emoji(message_object, random.choice(emojis))
         else:
-            not_running = await self.pm.clientWrap.send_message(self.name, message_object.channel,
-                                                                "There is no active or open race at this moment! "
-                                                                "Please start one with '!race'")
+            # this will always be a single message
+            not_running = (await self.pm.clientWrap.send_message(self.name, message_object.channel,
+                                                                 "There is no active or open race at this moment! "
+                                                                 "Please start one with '!race'"))[0]
             await asyncio.sleep(3)
             await not_running.delete()
 

--- a/plugins/examples/EventHandlerExamples.py
+++ b/plugins/examples/EventHandlerExamples.py
@@ -15,13 +15,13 @@ class Plugin(AbstractPlugin):
         return [Events.Typing("example_typing"), Events.MessageDelete("example_delete")]
 
     async def handle_typing(self, channel, user, when):
-        '''tmp = await self.pm.client.send_message(channel, user.name + " is typing, wow!")
+        '''tmp = (await self.pm.client.send_message(channel, user.name + " is typing, wow!"))[0]
         await asyncio.sleep(5)
         await self.pm.client.delete_message(tmp)'''
 
     async def handle_message_delete(self, message):
-        '''tmp = await self.pm.client.send_message(message.channel,
-                                                "Message deleted (" + message.author.name + "): " + message.content)
+        '''tmp = (await self.pm.client.send_message(message.channel,
+                                                 "Message deleted (" + message.author.name + "): " + message.content))[0]
         await asyncio.sleep(5)
         await self.pm.client.delete_message(tmp)'''
 


### PR DESCRIPTION
Fixes #31
The send_message now returns an array of messages (even if the original message was not split). It makes it a tiny bit clumsy in cases where we are sure that the message doesn't exceed the limit, can use send_message_raw if it's an issue.